### PR TITLE
Missing 'on_delete' argument when creating ForeignKey type.

### DIFF
--- a/en/homework_create_more_models/README.md
+++ b/en/homework_create_more_models/README.md
@@ -8,7 +8,7 @@ Let's open `blog/models.py` and append this piece of code to the end of file:
 
 ```python
 class Comment(models.Model):
-    post = models.ForeignKey('blog.Post', related_name='comments')
+    post = models.ForeignKey('blog.Post', on_delete=models.CASCADE, related_name='comments')
     author = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(default=timezone.now)


### PR DESCRIPTION
Set 'on_delete' argument as 'models.CASCADE' when using models.ForeignKey() to create field 'post'.